### PR TITLE
Use frozen string literal pragma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in eclair.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require "bundler/gem_tasks"

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "eclair"
 

--- a/eclair.gemspec
+++ b/eclair.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/exe/ecl
+++ b/exe/ecl
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "eclair"
 require "eclair/grid"

--- a/lib/eclair.rb
+++ b/lib/eclair.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Eclair
 end
 

--- a/lib/eclair/color.rb
+++ b/lib/eclair/color.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'curses'
 
 module Eclair

--- a/lib/eclair/config.rb
+++ b/lib/eclair/config.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'curses'
 
 module Eclair
@@ -6,7 +7,7 @@ module Eclair
       Eclair.config
     end
   end
-  
+
   class Config
     KEYS_DIR = "#{ENV['HOME']}/.ecl/keys"
     CACHE_DIR = "#{ENV['HOME']}/.ecl/.cache"

--- a/lib/eclair/grid.rb
+++ b/lib/eclair/grid.rb
@@ -1,5 +1,4 @@
-
-
+# frozen_string_literal: true
 require "eclair/group_item"
 require "eclair/color"
 
@@ -15,7 +14,7 @@ module Eclair
         @provider = K8sProvider
       end
       @item_class = @provider.item_class
-      
+
       @grid = config.columns.times.map{[]}
       @scroll = config.columns.times.map{0}
       @header_rows = 4
@@ -28,7 +27,7 @@ module Eclair
       assign
       at(*@cursor).toggle_select
       draw_all
-    end    
+    end
 
     def move key
       prev = @cursor.dup
@@ -79,7 +78,7 @@ module Eclair
     def action
       targets = @provider.items.select{|i| i.selected}
       return if targets.length == 0
-      
+
       Curses.close_screen
 
       if targets.length == 1
@@ -131,7 +130,7 @@ module Eclair
         Curses.addstr(line)
       end
     end
-    
+
     def rescroll x, y
       unless (@scroll[x]...@maxy+@scroll[x]).include? y
         if y < @scroll[x]
@@ -144,7 +143,7 @@ module Eclair
         end
       end
     end
-      
+
     def at x, y
       @grid[x][y]
     end
@@ -163,9 +162,9 @@ module Eclair
       end
       update_header(at(*@cursor).header)
     end
-    
+
     def color x, y
-      if @cursor == [x,y] 
+      if @cursor == [x,y]
         Color.fetch(Curses::COLOR_BLACK, Curses::COLOR_CYAN)
       else
         Color.fetch(*@grid[x][y].color)
@@ -174,7 +173,7 @@ module Eclair
 
     def draw_item x, y
       target = @grid[x][y]
-      
+
       drawy = y - @scroll[x]
       if drawy < 0 || drawy + @header_rows >= Curses.stdscr.maxy
         return

--- a/lib/eclair/group_item.rb
+++ b/lib/eclair/group_item.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
 module Eclair
   class GroupItem < Item
     attr_reader :label
-    
+
     def initialize label, items
       @label = label
       @items = items
@@ -18,10 +19,9 @@ module Eclair
     def length
       @items.length
     end
-    
+
     def color
       [Curses::COLOR_WHITE, -1, Curses::A_BOLD]
     end
   end
 end
-

--- a/lib/eclair/item.rb
+++ b/lib/eclair/item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "eclair/config"
 
 module Eclair
@@ -15,7 +16,7 @@ module Eclair
     def search
       raise "Not Implemented"
     end
-    
+
     def config
       Eclair.config
     end
@@ -40,7 +41,7 @@ module Eclair
     def command
       raise "Not Implemented"
     end
-    
+
     def header
       raise "Not Implemented"
     end

--- a/lib/eclair/less_viewer.rb
+++ b/lib/eclair/less_viewer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Eclair
   module LessViewer
     extend self

--- a/lib/eclair/provider.rb
+++ b/lib/eclair/provider.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Eclair
   module Provider
     extend self

--- a/lib/eclair/providers/ec2.rb
+++ b/lib/eclair/providers/ec2.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require "eclair/providers/ec2/ec2_provider"

--- a/lib/eclair/providers/ec2/ec2_group_item.rb
+++ b/lib/eclair/providers/ec2/ec2_group_item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "eclair/group_item"
 
 module Eclair
@@ -13,4 +14,3 @@ module Eclair
     end
   end
 end
-

--- a/lib/eclair/providers/ec2/ec2_item.rb
+++ b/lib/eclair/providers/ec2/ec2_item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "aws-sdk-ec2"
 
 require "eclair/item"
@@ -6,7 +7,7 @@ require "eclair/providers/ec2/ec2_provider"
 module Eclair
   class EC2Item < Item
     attr_reader :instance
-    
+
     def initialize instance
       super()
       @instance = instance
@@ -34,7 +35,7 @@ module Eclair
       username = config.ssh_username.call(image)
       key_cmd = config.ssh_keys[@instance.key_name] ? "-i #{config.ssh_keys[@instance.key_name]}" : ""
       format = config.exec_format
-      
+
       joined_cmd = hosts.map do |host|
         ports.map do |port|
           {
@@ -50,7 +51,7 @@ module Eclair
       # puts joined_cmd
       "echo Attaching to #{name} \\[#{@instance.instance_id}\\] && #{joined_cmd}"
     end
-    
+
     def header
       <<-EOS
       #{name} (#{instance_id}) [#{state[:name]}]
@@ -72,7 +73,7 @@ module Eclair
       launched at #{@instance.launch_time.to_time}
       EOS
     end
-    
+
     def label
       " - #{name} [#{launched_at}]"
     end
@@ -96,7 +97,7 @@ module Eclair
         @name = "terminated"
       end
     end
-    
+
     def security_groups
       @security_groups ||= @instance.security_groups.map{|sg| provider.find_security_group_by_id(sg.group_id)}
     end

--- a/lib/eclair/providers/ec2/ec2_provider.rb
+++ b/lib/eclair/providers/ec2/ec2_provider.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "aws-sdk-ec2"
 require "eclair/provider"
 require "eclair/providers/ec2/ec2_item"
@@ -20,20 +21,20 @@ module Eclair
       Thread.abort_on_exception = true
 
       @instances ||= fetch_instances
-      
+
       image_ids = @instances.map(&:image_id).uniq
       @image_thread = Thread.new do
         @images = fetch_images(image_ids)
         @id_to_image = @images.map{|i| [i.image_id, i]}.to_h
       end
-      
+
       @sg_thread = Thread.new do
         @security_groups = fetch_security_groups
         @id_to_sg = @security_groups.map{|i| [i.group_id, i]}.to_h
       end
 
-      @vpc_thread = Thread.new do 
-        @vpcs = fetch_vpcs 
+      @vpc_thread = Thread.new do
+        @vpcs = fetch_vpcs
         @id_to_vpc = @vpcs.map{|i| [i.vpc_id, i]}.to_h
       end
 
@@ -95,19 +96,19 @@ module Eclair
     end
 
     def fetch_instances
-      ec2_client.describe_instances.map{ |resp| 
+      ec2_client.describe_instances.map{ |resp|
         resp.data.reservations.map do |rsv|
           rsv.instances
         end
       }.flatten
     end
-      
+
     def fetch_security_groups
       ec2_client.describe_security_groups.map{ |resp|
         resp.security_groups
       }.flatten
     end
-    
+
     def fetch_images image_ids
       ec2_client.describe_images(image_ids: image_ids).images.flatten
     end

--- a/lib/eclair/providers/k8s.rb
+++ b/lib/eclair/providers/k8s.rb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require "eclair/providers/k8s/k8s_provider"

--- a/lib/eclair/providers/k8s/k8s_group_item.rb
+++ b/lib/eclair/providers/k8s/k8s_group_item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "eclair/group_item"
 
 module Eclair
@@ -12,4 +13,3 @@ module Eclair
     end
   end
 end
-

--- a/lib/eclair/providers/k8s/k8s_item.rb
+++ b/lib/eclair/providers/k8s/k8s_item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'eclair/item'
 require 'eclair/providers/k8s/k8s_provider'
 require 'time'
@@ -5,7 +6,7 @@ require 'time'
 module Eclair
   class K8sItem < Item
     attr_reader :pod
-    
+
     def initialize pod
       super()
       @pod = pod
@@ -26,7 +27,7 @@ module Eclair
     def command
       "kubectl exec --namespace #{namespace} -ti #{name} /bin/sh"
     end
-    
+
     def header
       <<-EOS
       #{name}
@@ -51,7 +52,7 @@ module Eclair
     def launch_time
       Time.parse(@pod["metadata"]["creationTimestamp"])
     end
-    
+
     def launched_at
       diff = Time.now - launch_time
       {
@@ -71,4 +72,3 @@ module Eclair
     end
   end
 end
-

--- a/lib/eclair/providers/k8s/k8s_provider.rb
+++ b/lib/eclair/providers/k8s/k8s_provider.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'eclair/provider'
 require 'eclair/providers/k8s/k8s_item'
 require 'eclair/providers/k8s/k8s_group_item'

--- a/lib/eclair/version.rb
+++ b/lib/eclair/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Eclair
   VERSION = "3.0.0-alpha1"
 end

--- a/templates/eclrc.template
+++ b/templates/eclrc.template
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Eclair.configure do |config|
   # aws_region - AWS region to connect.
   # This overrides AWS_REGION environment variable, so you can comment out this line if you set this in environment variable.


### PR DESCRIPTION
Let's use frozen string literal pragma. It'll reduce object allocation and improve performance. Frozen string literal will be default in Ruby 3.0.

###### Reference
- https://bugs.ruby-lang.org/issues/11473