### PR TITLE
Make EC2Item#name and EC2Item#security_groups methods public

### DIFF
--- a/lib/eclair/providers/ec2/ec2_item.rb
+++ b/lib/eclair/providers/ec2/ec2_item.rb
@@ -90,8 +90,6 @@ module Eclair
       ![32, 48, 80].include?(@instance.state[:code])
     end
 
-    private
-
     def name
       return @name if @name
       begin
@@ -105,6 +103,8 @@ module Eclair
     def security_groups
       @security_groups ||= @instance.security_groups.map{|sg| provider.find_security_group_by_id(sg.group_id)}
     end
+
+    private
 
     def launched_at
       diff = Time.now - @instance.launch_time


### PR DESCRIPTION
This is required since [`EC2Item#security_groups`](https://github.com/devsisters/eclair/blob/943c979ee71ae8efce748543a75ac0f3d3f40174/lib/eclair/providers/ec2/ec2_item.rb#L105) method is referenced by [`Eclair::Config`](https://github.com/devsisters/eclair/blob/943c979ee71ae8efce748543a75ac0f3d3f40174/lib/eclair/config.rb#L11)

https://github.com/devsisters/eclair/blob/943c979ee71ae8efce748543a75ac0f3d3f40174/lib/eclair/config.rb#L20-L26