### PR TITLE
Add experimental gce provider

### DIFF
--- a/lib/eclair/grid.rb
+++ b/lib/eclair/grid.rb
@@ -12,6 +12,9 @@ module Eclair
       when :k8s
         require "eclair/providers/k8s"
         @provider = K8sProvider
+      when :gce
+        require "eclair/providers/gce"
+        @provider = GCEProvider
       end
       @item_class = @provider.item_class
 

--- a/lib/eclair/providers/gce.rb
+++ b/lib/eclair/providers/gce.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+require "eclair/providers/gce/gce_provider"

--- a/lib/eclair/providers/gce/gce_group_item.rb
+++ b/lib/eclair/providers/gce/gce_group_item.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require "eclair/group_item"
+
+module Eclair
+  class GCEGroupItem < GroupItem
+    def header
+      all = @items.count
+
+      <<-EOS
+      Group #{label}
+      #{all} instances Total
+      EOS
+    end
+  end
+end

--- a/lib/eclair/providers/gce/gce_item.rb
+++ b/lib/eclair/providers/gce/gce_item.rb
@@ -89,7 +89,7 @@ module Eclair
     end
 
     def launch_time
-      Time.parse(@instance["creationTimestamp"])
+      Time.parse(@instance["creationTimestamp"]).localtime
     end
 
     def launched_at

--- a/lib/eclair/providers/gce/gce_item.rb
+++ b/lib/eclair/providers/gce/gce_item.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+require 'eclair/item'
+require 'eclair/providers/gce/gce_provider'
+require 'time'
+
+module Eclair
+  class GCEItem < Item
+    attr_reader :instance
+
+    def initialize instance
+      super()
+      @instance = instance
+    end
+
+    def id
+      @instance["id"]
+    end
+
+    def color
+      if @selected
+        [Curses::COLOR_YELLOW, -1, Curses::A_BOLD]
+      elsif !connectable?
+        [Curses::COLOR_BLACK, -1, Curses::A_BOLD]
+      else
+        [Curses::COLOR_WHITE, -1]
+      end
+    end
+
+    def header
+      <<-EOS
+      #{name} (#{public_ip_address} #{private_ip_address})
+      launched at #{launch_time.to_time}
+      #{description}
+      EOS
+    end
+
+    def label
+      " - #{name} [#{launched_at}]"
+    end
+
+    def description
+      @instance["description"]
+    end
+
+    def name
+      @instance["name"]
+    end
+
+    def public_ip_address
+      @instance["networkInterfaces"][0]["accessConfigs"][0]["natIP"]
+    end
+
+    def private_ip_address
+      @instance["networkInterfaces"][0]["networkIP"]
+    end
+
+    def command
+      hosts = [public_ip_address, private_ip_address].compact
+      ports = config.ssh_ports
+      ssh_options = config.ssh_options
+      ssh_command = config.ssh_command
+      username = "ubuntu"
+      format = config.exec_format
+
+      joined_cmd = hosts.map do |host|
+        ports.map do |port|
+          {
+            "{ssh_command}" => ssh_command,
+            "{ssh_options}" => ssh_options,
+            "{port}"        => port,
+            "{username}"    => username,
+            "{host}"        => host,
+          }.reduce(format) { |cmd,pair| cmd.sub(pair[0],pair[1].to_s) }
+        end
+      end.join(" || ")
+      # puts joined_cmd
+      "echo Attaching to #{name} \\[#{name}\\] && #{joined_cmd}"
+    end
+
+    def connectable?
+      status == "RUNNING"
+    end
+
+    private
+
+    def status
+      @instance["status"]
+    end
+
+    def launch_time
+      Time.parse(@instance["creationTimestamp"])
+    end
+
+    def launched_at
+      diff = Time.now - launch_time
+      {
+        "year" => 31557600,
+        "month" => 2592000,
+        "day" => 86400,
+        "hour" => 3600,
+        "minute" => 60,
+        "second" => 1
+      }.each do |unit,v|
+        if diff >= v
+          value = (diff/v).to_i
+          return "#{value} #{unit}#{value > 1 ? "s" : ""}"
+        end
+      end
+      "now"
+    end
+  end
+end

--- a/lib/eclair/providers/gce/gce_item.rb
+++ b/lib/eclair/providers/gce/gce_item.rb
@@ -55,7 +55,7 @@ module Eclair
     end
 
     def command
-      hosts = [public_ip_address, private_ip_address].compact
+      hosts = [private_ip_address, public_ip_address].compact
       ports = config.ssh_ports
       ssh_options = config.ssh_options
       ssh_command = config.ssh_command
@@ -70,6 +70,7 @@ module Eclair
             "{port}"        => port,
             "{username}"    => username,
             "{host}"        => host,
+            "{ssh_key}"     => ""
           }.reduce(format) { |cmd,pair| cmd.sub(pair[0],pair[1].to_s) }
         end
       end.join(" || ")

--- a/lib/eclair/providers/gce/gce_item.rb
+++ b/lib/eclair/providers/gce/gce_item.rb
@@ -47,11 +47,11 @@ module Eclair
     end
 
     def public_ip_address
-      @instance["networkInterfaces"][0]["accessConfigs"][0]["natIP"]
+      @instance.dig("networkInterfaces", 0, "accessConfigs", 0, "natIP")
     end
 
     def private_ip_address
-      @instance["networkInterfaces"][0]["networkIP"]
+      @instance.dig("networkInterfaces", 0, "networkIP")
     end
 
     def command

--- a/lib/eclair/providers/gce/gce_provider.rb
+++ b/lib/eclair/providers/gce/gce_provider.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'eclair/provider'
+require 'eclair/providers/gce/gce_item'
+require 'eclair/providers/gce/gce_group_item'
+require 'oj'
+
+module Eclair
+  module GCEProvider
+    extend Provider
+    extend self
+
+    def group_class
+      GCEGroupItem
+    end
+
+    def item_class
+      GCEItem
+    end
+
+    def prepare keyword
+      instances = Oj.load(`gcloud compute instances list --format=json`)
+      @items = instances.map{|i| GCEItem.new(i)}
+    end
+
+    def items
+      @items
+    end
+
+    private
+    def config
+      Eclair.config
+    end
+  end
+end


### PR DESCRIPTION
This commit adds experimental support for the Google Compute Engine instances.

The implementation currently has many limitations, including:
* username is hard-coded as `ubuntu`
* expect all instances have a public IP address