### PR TITLE
Show private ip address in header

### DIFF
--- a/lib/eclair/providers/ec2/ec2_item.rb
+++ b/lib/eclair/providers/ec2/ec2_item.rb
@@ -53,13 +53,6 @@ module Eclair
       "echo Attaching to #{Shellwords.escape(name)} \\[#{@instance.instance_id}\\] && #{joined_cmd}"
     end
 
-    def header
-      <<-EOS
-      #{name} (#{instance_id}) [#{state[:name]}]
-      launched at #{launch_time.to_time}
-      EOS
-    end
-
     def image
       @image ||= provider.find_image_by_id(@instance.image_id)
     end

--- a/lib/eclair/providers/ec2/ec2_item.rb
+++ b/lib/eclair/providers/ec2/ec2_item.rb
@@ -70,7 +70,7 @@ module Eclair
 
     def header
       <<-EOS
-      #{name} (#{@instance.instance_id}) [#{@instance.state[:name]}]
+      #{name} (#{@instance.instance_id}) [#{@instance.state[:name]}] #{@instance.private_ip_address}
       launched at #{@instance.launch_time.to_time}
       EOS
     end


### PR DESCRIPTION
In the previous versions the header showed the private ip address of the instance, but now that part is not there.

This pull request adds back the private ip into the header. Also deletes a duplicated code part.