### PR TITLE
Add configuration entry to use VPC_ID environment variable for filter…

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ config.ssh_keys = {
 }
 ```
 
+### filter by vpc_id
+Boolean variable. If ture use VPC_ID Environment variable for filtering EC2 instances.
+```ruby
+config.use_vpc_id_env = true
+```
+
+Example VPC_ID variable:
+```
+VPC_ID=vpc-12345678901234567
+```
+
 &nbsp;
 
 Install from Source

--- a/lib/eclair/config.rb
+++ b/lib/eclair/config.rb
@@ -40,6 +40,7 @@ module Eclair
       @exec_format          = "{ssh_command} {ssh_options} -p{port} {ssh_key} {username}@{host}"
       @provider             = :ec2
       @get_pods_option      = ""
+      @use_vpc_id_env       = false
 
       instance_variables.each do |var|
         Config.class_eval do

--- a/lib/eclair/provider.rb
+++ b/lib/eclair/provider.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
+require "eclair/config"
+
 module Eclair
   module Provider
+    include ConfigHelper
+
     extend self
     attr_accessor :items
 

--- a/lib/eclair/providers/ec2/ec2_provider.rb
+++ b/lib/eclair/providers/ec2/ec2_provider.rb
@@ -93,6 +93,13 @@ module Eclair
 
     def fetch_instances keyword
       filter = if keyword.empty? then {} else { filters: [{name: "tag:Name", values: ["*#{keyword}*"]}] } end
+      if config.use_vpc_id_env then
+        if filter.empty? then
+          filter = { filters: [{name: "vpc-id", values: [ENV['VPC_ID']]}] }
+        else
+          filter[:filters].push({name: "vpc-id", values: [ENV['VPC_ID']]})
+        end
+     end
 
       ec2_client.describe_instances(filter).map{ |resp|
         resp.data.reservations.map do |rsv|


### PR DESCRIPTION
I have many VPCs in AWS and every VPC is isolated from each other via Security Groups. That means that  I see many instances in ecl, but can't connect to them.

This Pull Request provides a Boolean configuration variable, to filter out every ec2 instance that is not in the VPC what I set to `VPC_ID`  environment variable. By default this is filter is disabled.

See the Readme.md for example.