### PR TITLE
add a version constraint of curses up to 1.4.2

### DIFF
--- a/eclair.gemspec
+++ b/eclair.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
 
   spec.add_runtime_dependency "aws-sdk-ec2", "~> 1.18"
-  spec.add_runtime_dependency "curses", "~> 1.0"
+  spec.add_runtime_dependency "curses", "~> 1.0", '<= 1.4.2'
   spec.add_runtime_dependency "ruby-string-match-scorer", "~> 0.1"
   spec.add_runtime_dependency "pry", "~> 0.10"
   spec.add_runtime_dependency "json", "~> 2.1"


### PR DESCRIPTION
H.

https://rubygems.org/gems/curses/versions/1.4.3
The minimum ruby version of Curses gem  was changed from 1.4.3.